### PR TITLE
fix: improve retry logic and fix concurrency issues

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,138 @@
+# the name by which the project can be referenced within Serena
+project_name: "retry"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- go
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/config.go
+++ b/config.go
@@ -227,5 +227,7 @@ func DefaultConfig() *Config {
 // FixConfig 函数返回一个新的固定退避时间的 Config 实例
 // The FixConfig function returns a new Config instance with a fixed backoff time
 func FixConfig() *Config {
-	return NewConfig().WithBackOffFunc(FixedBackoff).WithFactor(0).WithJitter(0)
+	return NewConfig().WithBackOffFunc(func(_ int64) time.Duration {
+		return defaultDelay
+	}).WithFactor(0).WithJitter(0)
 }

--- a/retry.go
+++ b/retry.go
@@ -1,7 +1,7 @@
 package retry
 
 import (
-	"math/rand"
+	"fmt"
 	"time"
 )
 
@@ -65,7 +65,7 @@ func (r *Result) FirstExecError() error {
 // ExecErrorByIndex 方法返回指定索引处的执行错误
 // The ExecErrorByIndex method returns the execution error at the specified index
 func (r *Result) ExecErrorByIndex(idx int) error {
-	if len(r.execErrors) >= 0 && idx < len(r.execErrors) {
+	if idx >= 0 && idx < len(r.execErrors) {
 		return r.execErrors[idx]
 	}
 	return ErrorExecErrByIndexOutOfBound
@@ -103,9 +103,16 @@ func (r *Retry) TryOnConflict(fn RetryableFunc) *Result {
 		return nil
 	}
 
-	// 创建一个新的定时器，定时器的延迟时间是 Config 中配置的延迟时间。定时器用于控制重试的间隔。
-	// Create a new timer. The delay time of the timer is the delay time configured in Config. The timer is used to control the interval between retries.
-	tr := time.NewTimer(r.config.delay)
+	// 创建 attemptsByError 的本地副本，避免并发访问共享 map 导致 data race
+	// Create a local copy of attemptsByError to avoid data race when accessing the shared map concurrently
+	localAttemptsByError := make(map[error]uint64, len(r.config.attemptsByError))
+	for k, v := range r.config.attemptsByError {
+		localAttemptsByError[k] = v
+	}
+
+	// 创建一个新的定时器，使用短初始延迟让第一次执行几乎立即进行。定时器用于控制重试的间隔。
+	// Create a new timer with a short initial delay so the first execution happens almost immediately. The timer is used to control the interval between retries.
+	tr := time.NewTimer(0)
 
 	// 使用 defer 关键字确保定时器在函数结束时停止，避免资源泄露。
 	// Use the defer keyword to ensure that the timer stops when the function ends, to avoid resource leaks.
@@ -118,6 +125,15 @@ func (r *Retry) TryOnConflict(fn RetryableFunc) *Result {
 	// 循环尝试执行 fn 函数，直到满足退出条件
 	// Loop to try to execute the fn function until the exit condition is met
 	for {
+		// 非阻塞检查 context 是否已取消，避免 timer(0) 与已取消 context 同时就绪时 select 随机选择通道
+		// Non-blocking check if context is already cancelled, to avoid random channel selection when timer(0) and cancelled context are both ready
+		select {
+		case <-r.config.ctx.Done():
+			result.tryError = r.config.ctx.Err()
+			return result
+		default:
+		}
+
 		select {
 		// 如果上下文已完成（例如，超时或手动取消），则将上下文的错误设置为结果的错误，并返回结果
 		// If the context is done (for example, timeout or manually cancelled), set the error of the context as the error of the result and return the result
@@ -160,27 +176,24 @@ func (r *Retry) TryOnConflict(fn RetryableFunc) *Result {
 			// 如果不需要重试，则返回结果
 			// If no retry is needed, return the result
 			if !r.config.retryIfFunc(err) {
-				// 将错误设置到结果中
-				// Set the error to the result
-				result.tryError = ErrorRetryIf
+				// 将 ErrorRetryIf 与原始错误一起包装到结果中，保留原始错误信息
+				// Wrap ErrorRetryIf together with the original error into the result, preserving the original error information
+				result.tryError = fmt.Errorf("%w: %w", ErrorRetryIf, err)
 
 				// 返回结果
 				// Return the result
 				return result
 			}
-			// 计算下一次重试的延迟时间，这里使用了一个随机的抖动和重试次数的乘积作为因子
-			// Calculate the delay time for the next retry, here a random jitter and the product of the number of retries are used as factors
-			delay := int64(rand.Float64()*float64(r.config.jitter) + float64(result.count)*r.config.factor)
+			// 计算下一次重试的线性延迟部分：随机抖动 + 重试次数 * 因子，再乘以基础延迟时间
+			// Calculate the linear delay component for the next retry: random jitter + retry count * factor, then multiply by base delay
+			randMu.Lock()
+			jitterVal := randGen.Float64()
+			randMu.Unlock()
+			delay := time.Duration(jitterVal*r.config.jitter+float64(result.count)*r.config.factor) * r.config.delay
 
-			// 如果计算出的延迟时间小于等于 0，则设置为默认的延迟时间
-			// If the calculated delay time is less than or equal to 0, set it to the default delay time
-			if delay <= 0 {
-				delay = defaultDelayNum
-			}
-
-			// 计算退避时间，这里使用了配置中的退避函数和延迟时间
-			// Calculate the backoff time, here the backoff function and delay time in the configuration are used
-			backoff := r.config.backoffFunc(int64(delay)) + r.config.delay
+			// 计算退避时间：退避函数接收当前重试次数作为参数，加上线性延迟部分
+			// Calculate the backoff time: backoff function receives the current retry count as parameter, plus the linear delay component
+			backoff := r.config.backoffFunc(int64(result.count)) + delay
 
 			// 调用配置中的回调函数，传入重试次数、退避时间和错误
 			// Call the callback function in the configuration, passing in the number of retries, backoff time, and error
@@ -190,7 +203,7 @@ func (r *Retry) TryOnConflict(fn RetryableFunc) *Result {
 			// First, we check if the retry count for a specific error has exceeded the limit
 			// 如果错误次数超过限制，则返回结果
 			// If the number of errors exceeds the limit, return the result
-			if errAttempts, ok := r.config.attemptsByError[err]; ok {
+			if errAttempts, ok := localAttemptsByError[err]; ok {
 				// 如果特定错误的重试次数已经用完，则返回一个错误，表示按错误类型的重试次数已经超过
 				// If the retry count for a specific error has been used up, return an error indicating that the retry count by error type has been exceeded
 				if errAttempts <= 0 {
@@ -206,7 +219,7 @@ func (r *Retry) TryOnConflict(fn RetryableFunc) *Result {
 				// 如果还有剩余的重试次数，则减少一次重试次数，并更新到配置中
 				// If there are remaining retry counts, decrease the retry count by one and update it in the configuration
 				errAttempts--
-				r.config.attemptsByError[err] = errAttempts
+				localAttemptsByError[err] = errAttempts
 			}
 
 			// 然后，我们检查总的执行次数是否已经超过限制

--- a/retry_test.go
+++ b/retry_test.go
@@ -48,10 +48,7 @@ func TestRetry_Do(t *testing.T) {
 }
 
 func TestRetry_DoWithDefault(t *testing.T) {
-	m := map[error]uint64{}
 	e := errors.New("test")
-	m[e] = 1
-
 	count := 0
 	testFunc := func() (any, error) {
 		if count > 0 {
@@ -169,7 +166,7 @@ func TestRetry_TryOnConflictRetryIf(t *testing.T) {
 	result := r.TryOnConflictVal(testFunc)
 	assert.NotNil(t, result)
 
-	assert.Equal(t, result.TryError(), ErrorRetryIf)
+	assert.True(t, errors.Is(result.TryError(), ErrorRetryIf))
 	assert.Equal(t, result.Count(), int64(1))
 }
 


### PR DESCRIPTION
- Fix concurrent map access data race by using local copy of attemptsByError
- Change first execution to start immediately with timer(0) instead of config delay
- Add non-blocking context cancellation check to avoid random select behavior
- Fix ExecErrorByIndex boundary check logic (was checking >= 0 incorrectly)
- Wrap ErrorRetryIf with original error using fmt.Errorf to preserve error info
- Update backoff calculation to use retry count instead of raw delay computation
- Fix FixConfig to use anonymous function instead of FixedBackoff
- Simplify test case and use errors.Is for wrapped error checking